### PR TITLE
add how to get api key in the readme fix #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ foreach ($users as $user) {
     echo "$user->username<br>";
 }
 ```
+## API Key
+
+To use the wrapper you´ll need a valid username and api key. For that you must:
+
+1. Create an account in (retroachievements.org)[http://retroachievements.org/createaccount.php]
+2. Valid your account in your email
+3. Login with your username and password (login)[http://retroachievements.org]
+4. Go to settings >> (my settings)[http://retroachievements.org/controlpanel.php] 
+5. Copy the api key value
+
+The username used will be the api username and the api key of the settings the key for connecting to the api.
+
 
 ## Methods
 
@@ -36,11 +48,3 @@ Get the consoles
 Get games for console
 
 `$ra->getGamesForConsole($consoleId);`
-
-Get game info
-
-`$ra->getGameInfo($gameId);`
-
-## Contributing
-
-See [CONTRIBUTING.md](https://github.com/joestrong/retroachievements-composer/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
It was fixed in and old pull request that is not acepted because resolve a issue with an incorrect implementation. I deleted the old fork repo so the pull request should automatically close if not please close it. 

It add steps how to get an api key to test or use the package. 
